### PR TITLE
feat: Add recipe steps by voice

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA" />
-
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />
 
     <application

--- a/app/src/main/res/layout/activity_create_recipe.xml
+++ b/app/src/main/res/layout/activity_create_recipe.xml
@@ -94,6 +94,14 @@
                 android:text="@string/create_recipe_steps_label"
                 android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
                 android:textColor="?attr/colorOnSurface"
+                android:layout_marginBottom="4dp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/create_recipe_voice_steps_instruction"
+                android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                android:textColor="?attr/colorOnSurfaceVariant"
                 android:layout_marginBottom="8dp" />
 
             <LinearLayout
@@ -103,21 +111,36 @@
                 android:orientation="vertical"
                 android:layout_marginBottom="8dp" />
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/btnAddStep"
-                style="@style/Widget.Material3.Button.IconButton.Filled"
-                android:layout_width="56dp"
-                android:layout_height="56dp"
-                android:layout_gravity="center"
-                app:icon="@drawable/ic_add_24"
-                app:iconGravity="textStart"
-                app:iconPadding="0dp"
-                android:insetLeft="0dp"
-                android:insetTop="0dp"
-                android:insetRight="0dp"
-                android:insetBottom="0dp"
-                android:contentDescription="@string/create_recipe_add_step"
-                android:layout_marginBottom="16dp" />
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:orientation="horizontal"
+                android:layout_marginBottom="16dp">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnAddStep"
+                    style="@style/Widget.Material3.Button.IconButton.Filled"
+                    android:layout_width="56dp"
+                    android:layout_height="56dp"
+                    app:icon="@drawable/ic_add_24"
+                    app:iconGravity="textStart"
+                    app:iconPadding="0dp"
+                    android:insetLeft="0dp"
+                    android:insetTop="0dp"
+                    android:insetRight="0dp"
+                    android:insetBottom="0dp"
+                    android:contentDescription="@string/create_recipe_add_step" />
+
+                <ImageButton
+                    android:id="@+id/btnVoiceInputSteps"
+                    android:layout_width="56dp"
+                    android:layout_height="56dp"
+                    android:src="@android:drawable/ic_btn_speak_now"
+                    android:contentDescription="@string/create_recipe_add_step_voice"
+                    android:layout_marginStart="16dp" />
+
+            </LinearLayout>
 
             <!-- Separador -->
             <View
@@ -155,8 +178,7 @@
                 android:insetTop="0dp"
                 android:insetRight="0dp"
                 android:insetBottom="0dp"
-                android:contentDescription="@string/create_recipe_add_ingredient"
-                android:layout_marginBottom="16dp" />
+                android:contentDescription="@string/create_recipe_add_ingredient" />
 
         </LinearLayout>
 
@@ -188,4 +210,3 @@
     </FrameLayout>
 
 </RelativeLayout>
-

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -121,11 +121,14 @@
     <string name="create_recipe_step_hint">Step</string>
     <string name="create_recipe_add_step">Add step</string>
     <string name="create_recipe_remove_step">Remove step</string>
+    <string name="create_recipe_add_step_voice">Add steps by voice</string>
+    <string name="create_recipe_voice_steps_instruction">(Dictate your steps and separate them with the word \"then\")</string>
     <string name="create_recipe_ingredients_label">Ingredients</string>
     <string name="create_recipe_ingredient_name_hint">ingredient</string>
     <string name="create_recipe_quantity_hint">quantity</string>
     <string name="create_recipe_unit_hint">ml</string>
     <string name="create_recipe_add_ingredient">Add ingredient</string>
+    <string name="create_recipe_add_ingredient_voice">Add ingredients by voice</string>
     <string name="create_recipe_remove_ingredient">Remove ingredient</string>
     <string name="create_recipe_save">Save</string>
     <string name="create_recipe_error_empty_fields">Please fill all fields</string>
@@ -137,6 +140,7 @@
     <string name="create_recipe_select_image_title">Select image</string>
     <string name="create_recipe_option_camera">Camera</string>
     <string name="create_recipe_option_gallery">Gallery</string>
+    <string name="voice_input_step_separator" translatable="false">then</string>
 
     <!-- Edit Recipe -->
     <string name="edit_recipe_title">Edit Recipe</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,11 +120,14 @@
     <string name="create_recipe_step_hint">Paso</string>
     <string name="create_recipe_add_step">Agregar paso</string>
     <string name="create_recipe_remove_step">Eliminar paso</string>
+    <string name="create_recipe_add_step_voice">Agregar pasos por voz</string>
+    <string name="create_recipe_voice_steps_instruction">(Dicta tus pasos y sepáralos con la palabra \"luego\")</string>
     <string name="create_recipe_ingredients_label">Ingredientes</string>
     <string name="create_recipe_ingredient_name_hint">ingrediente</string>
     <string name="create_recipe_quantity_hint">cantidad</string>
     <string name="create_recipe_unit_hint">ml</string>
     <string name="create_recipe_add_ingredient">Agregar ingrediente</string>
+    <string name="create_recipe_add_ingredient_voice">Agregar ingredientes por voz</string>
     <string name="create_recipe_remove_ingredient">Eliminar ingrediente</string>
     <string name="create_recipe_save">Guardar</string>
     <string name="create_recipe_error_empty_fields">Por favor completa todos los campos</string>
@@ -136,6 +139,7 @@
     <string name="create_recipe_select_image_title">Seleccionar imagen</string>
     <string name="create_recipe_option_camera">Cámara</string>
     <string name="create_recipe_option_gallery">Galería</string>
+    <string name="voice_input_step_separator" translatable="false">luego</string>
 
     <!-- Edit Recipe -->
     <string name="edit_recipe_title">Editar Receta</string>


### PR DESCRIPTION
This commit introduces the ability for users to add recipe steps using voice input.

Key changes:
- Adds a microphone button to the "Create Recipe" screen.
- Implements speech-to-text functionality to capture spoken steps.
- Parses the transcribed text, splitting it into individual steps using the separator "luego" (Spanish) or "then" (English).
- Adds the `RECORD_AUDIO` permission to the Android Manifest.
- Includes localization for the new feature in both English and Spanish.